### PR TITLE
Added ability to provide and use a SOCKS5 proxy only for TelegramBots…

### DIFF
--- a/telegrambots/src/main/java/org/telegram/telegrambots/facilities/ProxyPlainConnectionSocketFactory.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/facilities/ProxyPlainConnectionSocketFactory.java
@@ -1,0 +1,30 @@
+package org.telegram.telegrambots.facilities;
+
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.protocol.HttpContext;
+
+import java.net.Proxy;
+import java.net.Socket;
+import java.util.Objects;
+
+/**
+ * {@link PlainConnectionSocketFactory} implementation that passes a supplied {@link Proxy} instance to all created sockets.
+ * This implementation allows a telegram bot to use a socks5 proxy without forcing all JVM connections to use the same proxy.
+ *
+ * @author Vitaly Ogoltsov &lt;vitaly.ogoltsov@me.com&gt;
+ */
+@SuppressWarnings("WeakerAccess")
+public class ProxyPlainConnectionSocketFactory extends PlainConnectionSocketFactory {
+
+    private final Proxy proxy;
+
+    public ProxyPlainConnectionSocketFactory(Proxy proxy) {
+        this.proxy = Objects.requireNonNull(proxy);
+    }
+
+    @Override
+    public Socket createSocket(HttpContext context) {
+        return new Socket(proxy);
+    }
+
+}

--- a/telegrambots/src/main/java/org/telegram/telegrambots/facilities/ProxySSLConnectionSocketFactory.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/facilities/ProxySSLConnectionSocketFactory.java
@@ -1,0 +1,44 @@
+package org.telegram.telegrambots.facilities;
+
+import org.apache.http.HttpHost;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.protocol.HttpContext;
+
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.Socket;
+import java.util.Objects;
+
+/**
+ * {@link SSLConnectionSocketFactory} implementation that passes a supplied {@link Proxy} instance to all created sockets.
+ * This implementation allows a telegram bot to use a socks5 proxy without forcing all JVM connections to use the same proxy.
+ *
+ * @author Vitaly Ogoltsov &lt;vitaly.ogoltsov@me.com&gt;
+ */
+@SuppressWarnings("WeakerAccess")
+public class ProxySSLConnectionSocketFactory extends SSLConnectionSocketFactory {
+
+    private final Proxy proxy;
+
+    public ProxySSLConnectionSocketFactory(SSLContext sslContext, Proxy proxy) {
+        super(sslContext);
+        this.proxy = Objects.requireNonNull(proxy);
+    }
+
+    @Override
+    public Socket createSocket(final HttpContext context) {
+        return new Socket(proxy);
+    }
+
+    @Override
+    public Socket connectSocket(int connectTimeout, Socket socket, HttpHost host, InetSocketAddress remoteAddress,
+                                InetSocketAddress localAddress, HttpContext context) throws IOException {
+        // Convert address to unresolved
+        InetSocketAddress unresolvedRemote = InetSocketAddress
+                .createUnresolved(host.getHostName(), remoteAddress.getPort());
+        return super.connectSocket(connectTimeout, socket, host, unresolvedRemote, localAddress, context);
+    }
+
+}

--- a/telegrambots/src/main/java/org/telegram/telegrambots/facilities/TelegramHttpClientBuilder.java
+++ b/telegrambots/src/main/java/org/telegram/telegrambots/facilities/TelegramHttpClientBuilder.java
@@ -1,11 +1,26 @@
 package org.telegram.telegrambots.facilities;
 
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.ProxyAuthenticationStrategy;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.telegram.telegrambots.bots.DefaultBotOptions;
 
+import javax.net.ssl.SSLContext;
+import java.net.Authenticator;
+import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
+import java.net.Proxy;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -14,12 +29,62 @@ import java.util.concurrent.TimeUnit;
 public class TelegramHttpClientBuilder {
 
     public static CloseableHttpClient build(DefaultBotOptions options) {
+        HttpClientConnectionManager httpClientConnectionManager = null;
+
+        // to use a SOCKS5 proxy, we need to override connection socket factories used by Apache HttpClient by default
+        HttpHost proxyHost = options.getHttpProxy();
+        if (proxyHost != null && Objects.equals(proxyHost.getSchemeName(), "socks5")) {
+            try {
+                // remove proxy information from RequestConfig
+                RequestConfig requestConfig = options.getRequestConfig();
+                if (requestConfig != null) {
+                    // read proxy credentials from RequestConfig and provide a new Authenticator
+                    Credentials credentials = Optional.ofNullable(options.getCredentialsProvider())
+                            .map(credentialsProvider -> credentialsProvider.getCredentials(new AuthScope(proxyHost)))
+                            .orElse(null);
+                    if (requestConfig.isAuthenticationEnabled() && credentials != null) {
+                        Authenticator.setDefault(new Authenticator() {
+                            @Override
+                            protected PasswordAuthentication getPasswordAuthentication() {
+                                return new PasswordAuthentication(
+                                        credentials.getUserPrincipal().getName(),
+                                        credentials.getPassword().toCharArray()
+                                );
+                            }
+                        });
+                    }
+                    // make a copy of current request config setting proxy to null
+                    requestConfig = RequestConfig.copy(requestConfig)
+                            .setProxy(null)
+                            .build();
+                    options.setRequestConfig(requestConfig);
+                }
+                // provide new connection manager with proxy-enabled connection socket factories
+                Proxy proxy = new Proxy(Proxy.Type.SOCKS, new InetSocketAddress(proxyHost.getHostName(), proxyHost.getPort()));
+                httpClientConnectionManager = new PoolingHttpClientConnectionManager(
+                        RegistryBuilder.<ConnectionSocketFactory>create()
+                                .register("http", new ProxyPlainConnectionSocketFactory(proxy))
+                                .register("https", new ProxySSLConnectionSocketFactory(SSLContext.getDefault(), proxy))
+                                .build(),
+                        null,
+                        null,
+                        null,
+                        -1,
+                        TimeUnit.MILLISECONDS
+                );
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to register a SOCKS5 proxy", e);
+            }
+        }
+
+
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create()
+                .setConnectionManager(httpClientConnectionManager)
                 .setSSLHostnameVerifier(new NoopHostnameVerifier())
                 .setConnectionTimeToLive(70, TimeUnit.SECONDS)
                 .setMaxConnTotal(100);
 
-        if (options.getHttpProxy() != null) {
+        if (options.getHttpProxy() != null && !Objects.equals(options.getHttpProxy().getSchemeName(), "socks5")) {
 
             httpClientBuilder.setProxy(options.getHttpProxy());
 


### PR DESCRIPTION
… without forcing the JVM to use proxy for all outgoing connections.